### PR TITLE
Combine post and edit functions in the same button

### DIFF
--- a/scenes/components/text_options.tscn
+++ b/scenes/components/text_options.tscn
@@ -48,10 +48,6 @@ size_flags_stretch_ratio = 0.25
 layout_mode = 2
 text = "Get Posts"
 
-[node name="EditPost" type="Button" parent="."]
-layout_mode = 2
-text = "Edit Post"
-
 [node name="Post" type="Button" parent="."]
 layout_mode = 2
 text = "Post"

--- a/scripts/button_manager.gd
+++ b/scripts/button_manager.gd
@@ -27,7 +27,6 @@ signal clear_text;
 ## Send it ======
 
 @onready var get_posts = $GetPosts;
-@onready var edit_post = $EditPost;
 @onready var post = $Post;
 
 

--- a/scripts/button_manager.gd
+++ b/scripts/button_manager.gd
@@ -4,7 +4,6 @@ extends VBoxContainer;
 ## Signals =====
 
 signal get_devlogs;
-signal edit_curr_text;
 signal post_curr_text;
 
 signal import_file;
@@ -37,7 +36,6 @@ func _ready():
 	clear_post.pressed.connect(_on_clear_text_pressed);
 	
 	get_posts.pressed.connect(_on_get_posts_pressed);
-	edit_post.pressed.connect(_on_edit_post_pressed);
 	post.pressed.connect(_on_post_pressed);
 	
 	import_text.pressed.connect(_on_import_pressed);
@@ -46,10 +44,6 @@ func _ready():
 
 func _on_get_posts_pressed():
 	get_devlogs.emit();
-
-
-func _on_edit_post_pressed():
-	edit_curr_text.emit();
 
 
 func _on_post_pressed():


### PR DESCRIPTION
# Changes

- remove edit button
- remove references, signals for edit button
- combine edit and post functions together using a reference to the post-to-be-edited
- updated message for clearing the post
- clear all text after every successful post / edit (includes clearing edit reference, so no accidental posting / attempt to edit of the current post)