### PR TITLE
Redo popup

### DIFF
--- a/scenes/devlogs.tscn
+++ b/scenes/devlogs.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://cg4hagqhec5ke"]
+[gd_scene load_steps=17 format=3 uid="uid://cg4hagqhec5ke"]
 
 [ext_resource type="Theme" uid="uid://bg45fa5ynd7fs" path="res://assets/themes/theme_mail.tres" id="1_i2wg7"]
 [ext_resource type="Script" path="res://scripts/devlogs.gd" id="2_00vko"]
@@ -7,6 +7,7 @@
 [ext_resource type="Texture2D" uid="uid://c68nqgvrw67ro" path="res://assets/imgs/airplane.png" id="4_enp6g"]
 [ext_resource type="PackedScene" uid="uid://dvjxapeupcitp" path="res://scenes/components/border.tscn" id="6_hcaqf"]
 [ext_resource type="PackedScene" uid="uid://bd3yn3luhu540" path="res://scenes/finalize.tscn" id="6_kycab"]
+[ext_resource type="Script" path="res://scripts/workspace.gd" id="6_n2wff"]
 [ext_resource type="PackedScene" uid="uid://b7134j8afntpo" path="res://scenes/verify_user.tscn" id="7_36a3x"]
 [ext_resource type="PackedScene" uid="uid://bc4tgg3t4a85l" path="res://scenes/settings.tscn" id="7_adelr"]
 [ext_resource type="PackedScene" uid="uid://da0y0eeeu881k" path="res://scenes/editor.tscn" id="7_pu2kp"]
@@ -73,6 +74,7 @@ size_flags_stretch_ratio = 0.05
 [node name="MC" type="MarginContainer" parent="HB/VB"]
 layout_mode = 2
 size_flags_vertical = 3
+script = ExtResource("6_n2wff")
 
 [node name="Workspace" type="TabContainer" parent="HB/VB/MC"]
 layout_mode = 2

--- a/scenes/devlogs.tscn
+++ b/scenes/devlogs.tscn
@@ -71,51 +71,53 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 size_flags_stretch_ratio = 0.05
 
-[node name="MC" type="MarginContainer" parent="HB/VB"]
+[node name="Workspace" type="MarginContainer" parent="HB/VB"]
 layout_mode = 2
 size_flags_vertical = 3
 script = ExtResource("6_n2wff")
 
-[node name="Workspace" type="TabContainer" parent="HB/VB/MC"]
+[node name="Modules" type="TabContainer" parent="HB/VB/Workspace"]
 layout_mode = 2
 current_tab = 0
 drag_to_rearrange_enabled = true
 
-[node name="Finalize" parent="HB/VB/MC/Workspace" instance=ExtResource("6_kycab")]
+[node name="Finalize" parent="HB/VB/Workspace/Modules" instance=ExtResource("6_kycab")]
 layout_mode = 2
 metadata/_tab_index = 0
 
-[node name="Editor" parent="HB/VB/MC/Workspace" instance=ExtResource("7_pu2kp")]
+[node name="Editor" parent="HB/VB/Workspace/Modules" instance=ExtResource("7_pu2kp")]
 visible = false
 layout_mode = 2
 
-[node name="Preview" parent="HB/VB/MC/Workspace" instance=ExtResource("8_ah82n")]
+[node name="Preview" parent="HB/VB/Workspace/Modules" instance=ExtResource("8_ah82n")]
 visible = false
 layout_mode = 2
 
-[node name="Devlogs List" parent="HB/VB/MC/Workspace" instance=ExtResource("8_kywa6")]
+[node name="Devlogs List" parent="HB/VB/Workspace/Modules" instance=ExtResource("8_kywa6")]
 visible = false
 layout_mode = 2
 
-[node name="Images" parent="HB/VB/MC/Workspace" instance=ExtResource("12_hsrji")]
+[node name="Images" parent="HB/VB/Workspace/Modules" instance=ExtResource("12_hsrji")]
 visible = false
 layout_mode = 2
 metadata/_tab_index = 4
 
-[node name="Verify User" parent="HB/VB/MC/Workspace" instance=ExtResource("7_36a3x")]
+[node name="Verify User" parent="HB/VB/Workspace/Modules" instance=ExtResource("7_36a3x")]
 visible = false
 layout_mode = 2
 metadata/_tab_index = 5
 
-[node name="Settings" parent="HB/VB/MC/Workspace" instance=ExtResource("7_adelr")]
+[node name="Settings" parent="HB/VB/Workspace/Modules" instance=ExtResource("7_adelr")]
 visible = false
 layout_mode = 2
 metadata/_tab_index = 6
 
-[node name="Border" parent="HB/VB/MC" instance=ExtResource("6_hcaqf")]
+[node name="Border" parent="HB/VB/Workspace" instance=ExtResource("6_hcaqf")]
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/margin_top = 30
+
+[node name="FileDialog" parent="HB/VB/Workspace" instance=ExtResource("13_h1vm4")]
 
 [node name="S4" type="MarginContainer" parent="HB/VB"]
 layout_mode = 2
@@ -127,5 +129,3 @@ size_flags_stretch_ratio = 0.05
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.15
-
-[node name="FileDialog" parent="." instance=ExtResource("13_h1vm4")]

--- a/scenes/devlogs.tscn
+++ b/scenes/devlogs.tscn
@@ -80,6 +80,7 @@ script = ExtResource("6_n2wff")
 layout_mode = 2
 current_tab = 0
 drag_to_rearrange_enabled = true
+script = ExtResource("6_n2wff")
 
 [node name="Finalize" parent="HB/VB/Workspace/Modules" instance=ExtResource("6_kycab")]
 layout_mode = 2

--- a/scenes/devlogs.tscn
+++ b/scenes/devlogs.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://cg4hagqhec5ke"]
+[gd_scene load_steps=16 format=3 uid="uid://cg4hagqhec5ke"]
 
 [ext_resource type="Theme" uid="uid://bg45fa5ynd7fs" path="res://assets/themes/theme_mail.tres" id="1_i2wg7"]
 [ext_resource type="Script" path="res://scripts/devlogs.gd" id="2_00vko"]
@@ -12,7 +12,6 @@
 [ext_resource type="PackedScene" uid="uid://da0y0eeeu881k" path="res://scenes/editor.tscn" id="7_pu2kp"]
 [ext_resource type="PackedScene" uid="uid://dgwq3cnobx4ac" path="res://scenes/preview.tscn" id="8_ah82n"]
 [ext_resource type="PackedScene" uid="uid://dh4s812fafwvb" path="res://scenes/devlogs_list.tscn" id="8_kywa6"]
-[ext_resource type="PackedScene" uid="uid://cg4nnfhi2bqyp" path="res://scenes/components/popup_msg.tscn" id="9_4c6yf"]
 [ext_resource type="PackedScene" uid="uid://cijs2jun0ywe3" path="res://scenes/images.tscn" id="12_hsrji"]
 [ext_resource type="PackedScene" uid="uid://stqqmsajhpt6" path="res://scenes/working_file.tscn" id="13_h1vm4"]
 
@@ -115,10 +114,6 @@ metadata/_tab_index = 6
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/margin_top = 30
-
-[node name="MsgPopup" parent="HB/VB/MC" instance=ExtResource("9_4c6yf")]
-visible = false
-layout_mode = 2
 
 [node name="S4" type="MarginContainer" parent="HB/VB"]
 layout_mode = 2

--- a/scenes/verify_user.tscn
+++ b/scenes/verify_user.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://b7134j8afntpo"]
+[gd_scene load_steps=4 format=3 uid="uid://b7134j8afntpo"]
 
 [ext_resource type="Theme" uid="uid://bg45fa5ynd7fs" path="res://assets/themes/theme_mail.tres" id="1_oeo4h"]
 [ext_resource type="Script" path="res://scripts/verify_user.gd" id="1_wpyrc"]
-[ext_resource type="PackedScene" uid="uid://cg4nnfhi2bqyp" path="res://scenes/components/popup_msg.tscn" id="3_dgs37"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3pf87"]
 bg_color = Color(1, 1, 1, 1)
@@ -122,7 +121,3 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 
 [node name="ExpireTimer" type="Timer" parent="."]
-
-[node name="PopUpMsg" parent="." instance=ExtResource("3_dgs37")]
-visible = false
-layout_mode = 2

--- a/scripts/components/popup_msg.gd
+++ b/scripts/components/popup_msg.gd
@@ -1,15 +1,7 @@
 extends MarginContainer
 
-signal send_buttons(type: String, buttons: Dictionary);
 
-var yes_callable = null;
-var no_callable = null;
-
-func create_popup(
-	display_text: String, 
-	button_info: Dictionary,
-	type: AppInfo.MsgType,
-) -> void:
+func create_popup(display_text: String, button_info: Dictionary, type: AppInfo.MsgType):
 	set_msg(display_text);
 	setup_popup(type, button_info);
 
@@ -23,42 +15,30 @@ func setup_popup(type: AppInfo.MsgType, button_info: Dictionary) -> void:
 	var yes_action = get_node('Space/VB/HB/Yes');
 	var no_action = get_node('Space/VB/HB/No');
 	
+	
 	match type:
 		AppInfo.MsgType.Notification:
-			send_buttons.emit(type, {'yes': yes_action});
-			
-			yes_action.text = button_info['yes'][0];
-			
-			yes_action.pressed.connect(button_info['yes'][1]);
-			yes_callable = button_info['yes'][1];
+			yes_action.text = button_info['yes']['text'];
+			yes_action.pressed.connect(_on_yes_action.bind(button_info['yes']['action']));
 			
 			no_action.hide();
 		AppInfo.MsgType.RequireAction:
-			send_buttons.emit(type, {'yes': yes_action, 'no': no_action});
+			yes_action.text = button_info['yes']['text'];
+			no_action.text = button_info['no']['text'];
 			
-			yes_action.text = button_info['yes'][0];
-			no_action.text = button_info['no'][0];
-			
-			yes_action.pressed.connect(button_info['yes'][1]);
-			yes_callable = button_info['yes'][1];
-			no_action.pressed.connect(button_info['no'][1]);
-			no_callable = button_info['no'][1];
+			yes_action.pressed.connect(_on_yes_action.bind(button_info['yes']['action']));
+			no_action.pressed.connect(exit);
 			
 			no_action.show();
 	
 	show();
 
 
+func _on_yes_action(action: Callable):
+	action.call();
+	exit();
+
+
 func exit() -> void:
-	var yes_action = get_node('Space/VB/HB/Yes');
-	var no_action = get_node('Space/VB/HB/No');
-	
-	if (yes_callable):
-		yes_action.disconnect("pressed", yes_callable);
-		yes_callable = null;
-	
-	if (no_callable):
-		no_action.disconnect("pressed", no_callable);
-		no_callable = null;
-	
 	hide();
+	queue_free();

--- a/scripts/components/popup_msg.gd
+++ b/scripts/components/popup_msg.gd
@@ -19,7 +19,8 @@ func setup_popup(type: AppInfo.MsgType, button_info: Dictionary) -> void:
 	match type:
 		AppInfo.MsgType.Notification:
 			yes_action.text = button_info['yes']['text'];
-			yes_action.pressed.connect(_on_yes_action.bind(button_info['yes']['action']));
+			yes_action.pressed.connect(exit);
+			#yes_action.pressed.connect(_on_yes_action.bind(button_info['yes']['action']));
 			
 			no_action.hide();
 		AppInfo.MsgType.RequireAction:

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -50,14 +50,14 @@ func _ready():
 
 func _on_post_curr_text():
 	if (finalize.text_is_empty() || editor.text_is_empty()):
-		create_notif_popup("You haven't completed all parts of your post yet!");
+		workspace_container.create_notif_popup("You haven't completed all parts of your post yet!");
 		return;
 	
 	var config = ConfigFile.new();
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup(error, AppInfo.ErrorType.ConfigError);
+		workspace_container.create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return;
 	
 	var msg_type = "Edited" if post_list.get_edit_ref() != null else "Posted";
@@ -101,7 +101,7 @@ func _on_post_curr_text():
 	error = h_client.request(url, headers, HTTPClient.METHOD_PUT, body);
 	
 	if (error != OK):
-		create_error_popup(error, AppInfo.ErrorType.HTTPError);
+		workspace_container.create_error_popup(error, AppInfo.ErrorType.HTTPError);
 
 
 
@@ -136,7 +136,7 @@ func _on_http_post_completed(result, response_code, _headers, body):
 			r_msg += "Not implemented!";
 			print(response);
 	
-	create_notif_popup(r_msg);
+	workspace_container.create_notif_popup(r_msg);
 
 
 func _on_enable_buttons():
@@ -149,13 +149,13 @@ func _on_token_expired(refresh_token: bool):
 	menu_options.get_posts.disabled = true;
 	
 	if (refresh_token):
-		create_notif_popup("Update your refresh token please! (Steps 1,2,3)");
+		workspace_container.create_notif_popup("Update your refresh token please! (Steps 1,2,3)");
 	else:
-		create_notif_popup("Update your user token please! (Step 4)");
+		workspace_container.create_notif_popup("Update your user token please! (Step 4)");
 
 
 func _on_clear_text():
-	create_action_popup(
+	workspace_container.create_action_popup(
 		"Are you sure you want to clear EVERYTHING in this post?\n(Text, title, summary, post, file name, etc.)",
 		{ 'yes': "Clear All", 'no': 'Cancel' },
 		clear_post,
@@ -193,7 +193,7 @@ func update_preview():
 func failed_checks(result: int, response_code: int):
 	if (result != OK):
 		var error_result = "%d\nHTTP request response error.\nResult %d" % [response_code, result];
-		create_notif_popup(error_result);
+		workspace_container.create_notif_popup(error_result);
 		return true;
 
 

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -269,7 +269,6 @@ func _on_connect_startup(component: String):
 		"file_dialog":
 			file_dialog.clear_post.connect(clear_post);
 			file_dialog.fill_in_details.connect(fill_in_details);
-			file_dialog.create_notif_popup.connect(create_notif_popup);
 			file_dialog.collected_img.connect(_on_collected_img);
 		"verify_user":
 			verify_user.enable_buttons.connect(_on_enable_buttons);

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -232,11 +232,6 @@ func fill_in_details(post_info: Dictionary):
 	update_preview();
 
 
-func disconnect_popup():
-	#msg_popup.exit();
-	pass
-
-
 func _on_export_file():
 	file_dialog.export_file(finalize.get_filename(), text_preview.get_text());
 
@@ -277,9 +272,5 @@ func _on_connect_startup(component: String):
 		"settings":
 			pass
 		"devlogs_list":
-			post_list.create_error_popup.connect(create_error_popup);
-			post_list.create_notif_popup.connect(create_notif_popup);
-			post_list.create_popup.connect(create_popup);
-			post_list.disconnect_popup.connect(disconnect_popup);
 			post_list.clear_post.connect(clear_post);
 			post_list.fill_in_details.connect(fill_in_details);

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -275,8 +275,7 @@ func _on_connect_startup(component: String):
 			verify_user.refresh_token_expired.connect(_on_token_expired.bind(true));
 			verify_user.user_token_expired.connect(_on_token_expired.bind(false));
 		"settings":
-			settings.create_error_popup.connect(create_error_popup);
-			settings.create_notif_popup.connect(create_notif_popup);
+			pass
 		"devlogs_list":
 			post_list.create_error_popup.connect(create_error_popup);
 			post_list.create_notif_popup.connect(create_notif_popup);

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -157,14 +157,21 @@ func _on_token_expired(refresh_token: bool):
 
 
 func _on_clear_text():
+	create_action_popup(
+		"Are you sure you want to clear EVERYTHING in this post?\n(Text, title, summary, post, file name, etc.)",
+		{ 'yes': "Clear All", 'no': 'Cancel' },
+		clear_post,
+	);
+
+func create_action_popup(msg: String, button_txt: Dictionary, action: Callable):
 	var popup = load(popup_ref).instantiate();
 	workspace_container.add_child(popup);
 	
 	popup.create_popup(
-		"Are you sure you want to clear EVERYTHING in this post?\n(Text, title, summary, post, file name, etc.)",
+		msg,
 		{
-			'yes': { "text": "Clear All", "action": clear_post },
-			'no': { "text": "Cancel" }
+			'yes': { "text": button_txt.yes, "action":  action },
+			'no': { "text": button_txt.no }
 		},
 		AppInfo.MsgType.RequireAction
 	);
@@ -228,12 +235,16 @@ func get_curr_formatted_date():
 	return formatted_date;
 
 
-func create_notif_popup(code_text: String):
-	msg_popup.create_popup(
-		code_text,
-		{'yes': ["Ok", _on_hide_popup]},
+func create_notif_popup(msg: String):
+	var popup = load(popup_ref).instantiate();
+	workspace_container.add_child(popup);
+	
+	popup.create_popup(
+		msg,
+		{ 'yes': { "text": "Ok" } },
 		AppInfo.MsgType.Notification
 	);
+
 
 
 func create_error_popup(error_code: Error, error_type: AppInfo.ErrorType):
@@ -248,9 +259,12 @@ func create_error_popup(error_code: Error, error_type: AppInfo.ErrorType):
 	create_notif_popup(error_msg);
 
 
-func create_popup(msg_text: String, button_info: Dictionary, msg_type: AppInfo.MsgType):
-	msg_popup.create_popup(
-		msg_text,
+func create_popup(msg: String, button_info: Dictionary, msg_type: AppInfo.MsgType):
+	var popup = load(popup_ref).instantiate();
+	workspace_container.add_child(popup);
+	
+	popup.create_popup(
+		msg,
 		button_info,
 		msg_type
 	);
@@ -267,7 +281,8 @@ func fill_in_details(post_info: Dictionary):
 
 
 func disconnect_popup():
-	msg_popup.exit();
+	#msg_popup.exit();
+	pass
 
 
 func _on_export_file():

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -4,19 +4,19 @@ extends MarginContainer
 @onready var menu_options = $HB/MenuOptions;
 
 # Locations
-@onready var workspace_container = $HB/VB/MC;
+@onready var workspace_container = $HB/VB/Workspace;
 
 # Workspace Modules
-@onready var finalize = $HB/VB/MC/Workspace/Finalize;
-@onready var editor = $HB/VB/MC/Workspace/Editor;
-@onready var text_preview = $HB/VB/MC/Workspace/Preview;
-@onready var verify_user = $"HB/VB/MC/Workspace/Verify User";
-@onready var post_list = $"HB/VB/MC/Workspace/Devlogs List";
-@onready var settings = $HB/VB/MC/Workspace/Settings;
-@onready var images = $HB/VB/MC/Workspace/Images;
+@onready var finalize = $HB/VB/Workspace/Modules/Finalize;
+@onready var editor = $HB/VB/Workspace/Modules/Editor;
+@onready var text_preview = $HB/VB/Workspace/Modules/Preview;
+@onready var verify_user = $"HB/VB/Workspace/Modules/Verify User";
+@onready var post_list = $"HB/VB/Workspace/Modules/Devlogs List";
+@onready var settings = $HB/VB/Workspace/Modules/Settings;
+@onready var images = $HB/VB/Workspace/Modules/Images;
 
 # Import / Export
-@onready var file_dialog = $FileDialog;
+@onready var file_dialog = $HB/VB/Workspace/FileDialog;
 
 
 

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -18,8 +18,6 @@ extends MarginContainer
 # Import / Export
 @onready var file_dialog = $FileDialog;
 
-# Msg Popup
-var popup_ref = "res://scenes/components/popup_msg.tscn";
 
 
 # Temporary Variables
@@ -163,18 +161,6 @@ func _on_clear_text():
 		clear_post,
 	);
 
-func create_action_popup(msg: String, button_txt: Dictionary, action: Callable):
-	var popup = load(popup_ref).instantiate();
-	workspace_container.add_child(popup);
-	
-	popup.create_popup(
-		msg,
-		{
-			'yes': { "text": button_txt.yes, "action":  action },
-			'no': { "text": button_txt.no }
-		},
-		AppInfo.MsgType.RequireAction
-	);
 
 
 func clear_post():
@@ -234,40 +220,6 @@ func get_curr_formatted_date():
 	
 	return formatted_date;
 
-
-func create_notif_popup(msg: String):
-	var popup = load(popup_ref).instantiate();
-	workspace_container.add_child(popup);
-	
-	popup.create_popup(
-		msg,
-		{ 'yes': { "text": "Ok" } },
-		AppInfo.MsgType.Notification
-	);
-
-
-
-func create_error_popup(error_code: Error, error_type: AppInfo.ErrorType):
-	var error_msg = "%d\n" % error_code;
-	
-	match error_type:
-		AppInfo.ErrorType.ConfigError:
-			error_msg += "Failed to load config file.";
-		AppInfo.ErrorType.HTTPError:
-			error_msg += "Couldn't perform HTTP request.";
-	
-	create_notif_popup(error_msg);
-
-
-func create_popup(msg: String, button_info: Dictionary, msg_type: AppInfo.MsgType):
-	var popup = load(popup_ref).instantiate();
-	workspace_container.add_child(popup);
-	
-	popup.create_popup(
-		msg,
-		button_info,
-		msg_type
-	);
 
 
 func fill_in_details(post_info: Dictionary):

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -18,8 +18,8 @@ extends MarginContainer
 # Import / Export
 @onready var file_dialog = $FileDialog;
 
-# Message Popup
-@onready var msg_popup = $HB/VB/MC/MsgPopup;
+# Msg Popup
+var popup_ref = "res://scenes/components/popup_msg.tscn";
 
 
 # Temporary Variables

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -19,7 +19,6 @@ extends MarginContainer
 @onready var file_dialog = $HB/VB/Workspace/FileDialog;
 
 
-
 # Temporary Variables
 var creation_date = "";
 
@@ -104,7 +103,6 @@ func _on_post_curr_text():
 		workspace_container.create_error_popup(error, AppInfo.ErrorType.HTTPError);
 
 
-
 func _on_text_changed_preview(_new_text: String) -> void:
 	update_preview();
 
@@ -160,7 +158,6 @@ func _on_clear_text():
 		{ 'yes': "Clear All", 'no': 'Cancel' },
 		clear_post,
 	);
-
 
 
 func clear_post():
@@ -221,7 +218,6 @@ func get_curr_formatted_date():
 	return formatted_date;
 
 
-
 func fill_in_details(post_info: Dictionary):
 	creation_date = post_info["creation_date"];
 	finalize.set_post_title(post_info["post_title"]);
@@ -246,10 +242,6 @@ func _on_import_image():
 
 func _on_collected_img(img_data, img_name: String):
 	images.save_img(img_data, img_name);
-
-
-
-
 
 
 func _on_connect_startup(component: String):

--- a/scripts/devlogs.gd
+++ b/scripts/devlogs.gd
@@ -3,6 +3,9 @@ extends MarginContainer
 
 @onready var menu_options = $HB/MenuOptions;
 
+# Locations
+@onready var workspace_container = $HB/VB/MC;
+
 # Workspace Modules
 @onready var finalize = $HB/VB/MC/Workspace/Finalize;
 @onready var editor = $HB/VB/MC/Workspace/Editor;
@@ -154,16 +157,17 @@ func _on_token_expired(refresh_token: bool):
 
 
 func _on_clear_text():
-	msg_popup.create_popup(
-		"Are you sure you want to clear EVERYTHING for this post?\n(Text, title, summary, post, file name, etc.)",
-		{'yes': ["Clear All", _on_serious_clear_button_pressed], 'no': ["Cancel", _on_hide_popup]},
+	var popup = load(popup_ref).instantiate();
+	workspace_container.add_child(popup);
+	
+	popup.create_popup(
+		"Are you sure you want to clear EVERYTHING in this post?\n(Text, title, summary, post, file name, etc.)",
+		{
+			'yes': { "text": "Clear All", "action": clear_post },
+			'no': { "text": "Cancel" }
+		},
 		AppInfo.MsgType.RequireAction
 	);
-
-
-func _on_serious_clear_button_pressed():
-	msg_popup.exit();
-	clear_post();
 
 
 func clear_post():
@@ -174,7 +178,6 @@ func clear_post():
 	creation_date = "";
 	
 	post_list.set_edit_ref(null);
-
 
 
 func update_preview():
@@ -223,10 +226,6 @@ func get_curr_formatted_date():
 	formatted_date += "%d" % curr_time["day"];
 	
 	return formatted_date;
-
-
-func _on_hide_popup():
-	msg_popup.exit();
 
 
 func create_notif_popup(code_text: String):

--- a/scripts/devlogs_list.gd
+++ b/scripts/devlogs_list.gd
@@ -215,16 +215,10 @@ func check_format_text(text_blob) -> void:
 
 
 func _on_delete_button_pressed(log_entry_delete_button: Button):
-	get_parent().create_popup(
+	get_parent().create_action_popup(
 		"Are you sure you want to delete this post?",
-		{
-			'yes': { 
-				'text': "Delete Post", 
-				'action': _on_serious_delete_button_pressed.bind(log_entry_delete_button) 
-			}, 
-			'no': { 'text': "Cancel" } 
-		},
-		AppInfo.MsgType.RequireAction
+		{ 'yes': "Delete Post", 'no': "Cancel" },
+		_on_serious_delete_button_pressed.bind(log_entry_delete_button) 
 	);
 
 

--- a/scripts/devlogs_list.gd
+++ b/scripts/devlogs_list.gd
@@ -1,10 +1,6 @@
 extends MarginContainer
 
 signal connect_startup(component: String);
-signal create_error_popup(msg_text: String, err_type: AppInfo.ErrorType);
-signal create_notif_popup(msg_text: String);
-signal create_popup(msg_text: String, button_info: Dictionary, msg_type: AppInfo.MsgType);
-signal disconnect_popup;
 signal clear_post;
 signal fill_in_details(post_info: Dictionary);
 
@@ -97,7 +93,7 @@ func _on_get_devlogs():
 	var error = h_client.request(url, headers, HTTPClient.METHOD_GET);
 	
 	if (error != OK):
-		create_error_popup.emit(error, AppInfo.ErrorType.HTTPError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.HTTPError);
 
 
 func _on_http_get_posts_completed(result, response_code, _headers, body):
@@ -114,7 +110,7 @@ func _on_http_get_posts_completed(result, response_code, _headers, body):
 				else:
 					update_directory_ref(post["name"], post["download_url"], post["sha"]);
 		_:
-			create_notif_popup.emit("%d\nNot implemented!" % response_code);
+			get_parent().create_notif_popup("%d\nNot implemented!" % response_code);
 
 
 func _on_edit_button_pressed(button: Button):
@@ -122,7 +118,7 @@ func _on_edit_button_pressed(button: Button):
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup.emit(error, AppInfo.ErrorType.ConfigError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return;
 	
 	edit_button_ref = button;
@@ -144,7 +140,7 @@ func _on_edit_button_pressed(button: Button):
 	error = h_client.request(url, headers, HTTPClient.METHOD_GET);
 	
 	if (error != OK):
-		create_error_popup.emit(error, AppInfo.ErrorType.HTTPError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.HTTPError);
 		edit_button_ref = null;
 
 
@@ -157,7 +153,7 @@ func _on_http_download_text_completed(result, response_code, _headers, body):
 			var downloaded_text = body.get_string_from_utf8();
 			check_format_text(downloaded_text);
 		_:
-			create_notif_popup.emit("%d\nNot implemented!" % response_code);
+			get_parent().create_notif_popup("%d\nNot implemented!" % response_code);
 			
 			print(body.get_string_from_utf8());
 
@@ -215,13 +211,19 @@ func check_format_text(text_blob) -> void:
 					"project":
 						pass;
 					_:
-						create_notif_popup.emit("Not a recognizable file name!\nPlease edit a different file.");
+						get_parent().create_notif_popup("Not a recognizable file name!\nPlease edit a different file.");
 
 
 func _on_delete_button_pressed(log_entry_delete_button: Button):
-	create_popup.emit(
+	get_parent().create_popup(
 		"Are you sure you want to delete this post?",
-		{'yes': ["Delete Post", _on_serious_delete_button_pressed.bind(log_entry_delete_button)], 'no': ["Cancel", _on_hide_popup]},
+		{
+			'yes': { 
+				'text': "Delete Post", 
+				'action': _on_serious_delete_button_pressed.bind(log_entry_delete_button) 
+			}, 
+			'no': { 'text': "Cancel" } 
+		},
 		AppInfo.MsgType.RequireAction
 	);
 
@@ -229,13 +231,11 @@ func _on_delete_button_pressed(log_entry_delete_button: Button):
 func _on_serious_delete_button_pressed(log_entry_delete_button: Button):
 	var button_ref = log_entry_delete_button;
 	
-	disconnect_popup.emit();
-	
 	var config = ConfigFile.new();
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup.emit(error, AppInfo.ErrorType.ConfigError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return;
 	
 	var body = {
@@ -273,7 +273,7 @@ func _on_serious_delete_button_pressed(log_entry_delete_button: Button):
 	error = h_client.request(url, headers, HTTPClient.METHOD_DELETE, body);
 	
 	if (error != OK):
-		create_error_popup.emit(error, AppInfo.ErrorType.HTTPError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.HTTPError);
 	else:
 		if (edit_button_ref != null && (button_ref.get_meta("sha") == edit_button_ref.get_meta("sha"))):
 			clear_post.emit();
@@ -288,7 +288,7 @@ func load_config_file() -> ConfigFile:
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup.emit(error, AppInfo.ErrorType.ConfigError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return null;
 	
 	return config;
@@ -298,7 +298,7 @@ func load_config_file() -> ConfigFile:
 func failed_checks(result: int, response_code: int):
 	if (result != OK):
 		var error_result = "%d\nHTTP request response error.\nResult %d" % [response_code, result];
-		create_notif_popup.emit(error_result);
+		get_parent().create_notif_popup(error_result);
 		return true;
 
 
@@ -326,10 +326,6 @@ func check_file_name(curr_file_name: String) -> String:
 	return "";
 
 
-func _on_hide_popup():
-	disconnect_popup.emit();
-
-
 func _on_http_delete_post_completed(result, response_code, _headers, body):
 	if (failed_checks(result, response_code)):
 		return;
@@ -350,7 +346,7 @@ func _on_http_delete_post_completed(result, response_code, _headers, body):
 		_:
 			r_msg += "Not implemented!\n%s" % [response_code, response["message"]];
 	
-	create_notif_popup.emit(r_msg);
+	get_parent().create_notif_popup(r_msg);
 
 
 func get_edit_ref():
@@ -379,7 +375,7 @@ func edit_directory_file():
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup.emit(error, AppInfo.ErrorType.ConfigError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return;
 	
 	var body = {
@@ -418,7 +414,7 @@ func edit_directory_file():
 	error = h_client.request(url, headers, HTTPClient.METHOD_PUT, body);
 	
 	if (error != OK):
-		create_error_popup.emit(error, AppInfo.ErrorType.HTTPError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.HTTPError);
 
 
 
@@ -427,7 +423,7 @@ func get_directory_file():
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup.emit(error, AppInfo.ErrorType.ConfigError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return;
 	
 	update_dir = true;
@@ -448,7 +444,7 @@ func get_directory_file():
 	error = h_client.request(url, headers, HTTPClient.METHOD_GET);
 	
 	if (error != OK):
-		create_error_popup.emit(error, AppInfo.ErrorType.HTTPError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.HTTPError);
 
 
 func _on_http_edit_directory_completed(result, response_code, _headers, body):
@@ -468,7 +464,7 @@ func _on_http_edit_directory_completed(result, response_code, _headers, body):
 			r_msg += "Not implemented! Failed to edit directory";
 			clean_directory_edit();
 			print(response);
-			create_notif_popup.emit(r_msg);
+			get_parent().create_notif_popup(r_msg);
 
 
 func clean_directory_edit():
@@ -481,7 +477,7 @@ func fetch_directory_file():
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup.emit(error, AppInfo.ErrorType.ConfigError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return;
 	
 	var app_name = config.get_value("app_info", "app_name");
@@ -502,7 +498,7 @@ func fetch_directory_file():
 	error = h_client.request(url, headers, HTTPClient.METHOD_GET);
 	
 	if (error != OK):
-		create_error_popup.emit(error, AppInfo.ErrorType.HTTPError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.HTTPError);
 
 
 func _on_http_download_json_completed(result, response_code, _headers, body):
@@ -521,4 +517,4 @@ func _on_http_download_json_completed(result, response_code, _headers, body):
 		_:
 			r_msg += "Not implemented!";
 			print(response);
-			create_notif_popup.emit(r_msg);
+			get_parent().create_notif_popup(r_msg);

--- a/scripts/settings.gd
+++ b/scripts/settings.gd
@@ -9,8 +9,6 @@ extends MarginContainer
 # =====================
 
 signal connect_startup(component: String);
-signal create_error_popup(msg: String, err_type: AppInfo.ErrorType);
-signal create_notif_popup(msg: String);
 
 # =====================
 # ====== Methods ======
@@ -71,7 +69,7 @@ func save_settings(user_set: Dictionary) -> void:
 	
 	config.save("user://config.cfg");
 	
-	create_notif_popup.emit("Saved!");
+	get_parent().create_notif_popup("Saved!");
 
 
 # ============================
@@ -103,7 +101,7 @@ func load_config_file() -> ConfigFile:
 	var error = config.load("user://config.cfg");
 	
 	if error != OK:
-		create_error_popup.emit(error, AppInfo.ErrorType.ConfigError);
+		get_parent().create_error_popup(error, AppInfo.ErrorType.ConfigError);
 		return null;
 	
 	return config;

--- a/scripts/working_file.gd
+++ b/scripts/working_file.gd
@@ -1,7 +1,6 @@
 extends FileDialog
 
 signal connect_startup(component: String);
-signal create_notif_popup(msg_text: String);
 signal fill_in_details(post_info: Dictionary);
 signal clear_post;
 signal collected_img(img_data, img_name: String);
@@ -52,7 +51,7 @@ func _on_file_selected(path: String):
 			var filename = path.get_file();
 			
 			if (check_file_name(filename) == ""):
-				create_notif_popup.emit("Not a recognizable file name!\nPlease edit a different file.");
+				get_parent().create_notif_popup("Not a recognizable file name!\nPlease edit a different file.");
 				return;
 			
 			clear_post.emit();

--- a/scripts/workspace.gd
+++ b/scripts/workspace.gd
@@ -1,4 +1,4 @@
-extends MarginContainer
+extends Control
 
 # Msg Popup
 var popup_ref = "res://scenes/components/popup_msg.tscn";

--- a/scripts/workspace.gd
+++ b/scripts/workspace.gd
@@ -1,0 +1,51 @@
+extends MarginContainer
+
+# Msg Popup
+var popup_ref = "res://scenes/components/popup_msg.tscn";
+
+func create_popup(msg: String, button_info: Dictionary, msg_type: AppInfo.MsgType):
+	var popup = load(popup_ref).instantiate();
+	add_child(popup);
+	
+	popup.create_popup(
+		msg,
+		button_info,
+		msg_type
+	);
+
+
+func create_action_popup(msg: String, button_txt: Dictionary, action: Callable):
+	var popup = load(popup_ref).instantiate();
+	add_child(popup);
+	
+	popup.create_popup(
+		msg,
+		{
+			'yes': { "text": button_txt.yes, "action":  action },
+			'no': { "text": button_txt.no }
+		},
+		AppInfo.MsgType.RequireAction
+	);
+
+
+func create_notif_popup(msg: String):
+	var popup = load(popup_ref).instantiate();
+	add_child(popup);
+	
+	popup.create_popup(
+		msg,
+		{ 'yes': { "text": "Ok" } },
+		AppInfo.MsgType.Notification
+	);
+
+
+func create_error_popup(error_code: Error, error_type: AppInfo.ErrorType):
+	var error_msg = "%d\n" % error_code;
+	
+	match error_type:
+		AppInfo.ErrorType.ConfigError:
+			error_msg += "Failed to load config file.";
+		AppInfo.ErrorType.HTTPError:
+			error_msg += "Couldn't perform HTTP request.";
+	
+	create_notif_popup(error_msg);


### PR DESCRIPTION
# Changes

Resolves #41

- Popups are instantiated and freed after clicking an action
- They are separated for each message, instead of using one and replacing text, actions
- No signals now, instead call parent to create the popup (modules will exist in the workspace)
- No connections to popup signals, everything mostly in one place, less lines to watch

## Popup

- Call action from popup scene, instead of scene that created the popup
- Now use dictionary instead of array for button info, actions
- Remove unused signals
- No longer saving variables of callables
- Set action based on type of popup (notifications only can exit for example, no custom actions)